### PR TITLE
Support microformats2 and internationalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.0.X (unreleased)
+## 07/12/2016
+1. [](#new)
+- [microformats2](http://microformats.org) support
+- Dates are now translated in the `event_item` template, if `events.date_format.translate` setting
+
 # v1.0.9
 ## 07/04/2016
 1. [](#improved)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is an events plugin that works with [Grav CMS](http://getgrav.org)  1.0.10+
 
 [View the demo](https://grav.brandr.co/calendar/year:2016/month:03) *Sidenote: the demo is running the development version of this plugin. From time to time you may see features that haven't been released yet.*
 
-Also, check out this [Repo](https://github.com/kalebheitzman/grav-brandr-pages) of proper page setup for Calendar, Events, and Event.
+Also, check out this [Repo](https://github.com/kalebheitzman/grav-brandr-pages) for proper page setup for Calendar, Events, and Event.
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ From the root of your Grav install.
 $ bin/gpm install events
 ```
 
+### Configuration
+
+#### Date translations
+
+Date translations can be enabled by setting `date_format.translate` to true in the config. They use the official [Grav translation files](https://github.com/getgrav/grav/tree/develop/system/languages), so if your language is missing, don't hesitate to contribute upstream.
+
+#### Sidebar link
+
+The sidebar template `partials/events_sidebar.html.twig` provides, if set, a link to see more events.
+
+You can configure it by changing the value of `default_events_page` in the config. Note that the expected pagename is relative to the root of your website.
+
+So if you want to point to `YOUR_SITE/events` (or `YOUR_SITE/lang/events` if translations are enabled in Grav), just set it to `events`.
+
 ### Todo
 
 Blueprints and Templates are included in this plugin for the Frontend and Admin side of things. I don't know how to include them yet so please feel free to copy them over to your theme (or symlink them to keep up-to-date with Event Plugin updates).
@@ -103,9 +117,9 @@ A collection of weekend events.
 
 <ul>
     {% for event in events %}
-        <li>
-            <a href="{{ event.url }}">{{ event.title }}</a>
-            {{ event.header.event.start|date('F j, Y') }}
+        <li class="h-event">
+            <a href="{{ event.url }}" class="p-name u-url">{{ event.title }}</a>
+            <time class="dt-start" datetime="{{ event.header.event.start|date('c') }}">{{ event.header.event.start|date('F j, Y') }}</time>
         </li>
     {% endfor %}
 </ul>

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -41,7 +41,7 @@ form:
       type: text
       label: Default Date Format
       default: F j, Y h:ia
-    date_translate:
+    date_format.translate:
       type: toggle
       label: Translate dates
       highlight: 1

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,5 +1,5 @@
 name: Events
-version: 1.0.8
+version: 1.0.10
 description: "The **Events** plugin provides events for a Grav site using event frontmatter."
 icon: calendar
 author:

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -69,3 +69,11 @@ form:
         0: Disabled
       validate:
         type: bool
+    default_events_page:
+      type: text
+      label: The main page listing events
+      default: /events
+    sidebar_months:
+      type: text
+      label: Number of months for which to display next events in sidebar
+      default: 2

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -41,6 +41,16 @@ form:
       type: text
       label: Default Date Format
       default: F j, Y h:ia
+    date_translate:
+      type: toggle
+      label: Translate dates
+      highlight: 1
+      default: 0
+      options:
+        1: Enabled
+        0: Disabled
+      validate:
+        type: bool
     filter_combinator:
       type: text
       label: Filter Combinator
@@ -72,8 +82,4 @@ form:
     default_events_page:
       type: text
       label: The main page listing events
-      default: /events
-    sidebar_months:
-      type: text
-      label: Number of months for which to display next events in sidebar
-      default: 2
+      default: events

--- a/events.php
+++ b/events.php
@@ -12,7 +12,7 @@
  * @author     Kaleb Heitzman <kalebheitzman@gmail.com>
  * @copyright  2016 Kaleb Heitzman
  * @license    https://opensource.org/licenses/MIT MIT
- * @version    1.0.8
+ * @version    1.0.10
  * @link       https://github.com/kalebheitzman/grav-plugin-events
  * @since      1.0.0 Initial Release
  */

--- a/events.php
+++ b/events.php
@@ -63,9 +63,8 @@ use Events\Events;
  *
  * @package     Events
  * @author      Kaleb Heitzman <kalebheitzman@gmail.com>
- * @version 	1.0.8
+ * @version 	1.0.10
  * @since 		1.0.0 Initial Release
- * @todo 		Implement Localization
  * @todo 		Implement Date Formats
  * @todo 		Implement ICS Feeds
  * @todo 		Implement All Day Option

--- a/events.yaml
+++ b/events.yaml
@@ -10,3 +10,5 @@ event_template_types: calendar, events, event
 display_months_out: 3
 show_past_events: false
 enable_single_event_filter: true
+default_events_page: /events
+sidebar_months: 2

--- a/events.yaml
+++ b/events.yaml
@@ -1,10 +1,10 @@
 enabled: true
 date_format:
+    translate: true
     long: Y-m-d h:ia
     medium: m/d/Y
     short: M j
     default: F j, Y h:ia
-date_translate: false
 filter_combinator: and
 taxonomy_type: event
 event_template_types: calendar, events, event

--- a/events.yaml
+++ b/events.yaml
@@ -11,4 +11,3 @@ display_months_out: 3
 show_past_events: false
 enable_single_event_filter: true
 default_events_page: /events
-sidebar_months: 2

--- a/events.yaml
+++ b/events.yaml
@@ -4,10 +4,11 @@ date_format:
     medium: m/d/Y
     short: M j
     default: F j, Y h:ia
+date_translate: false
 filter_combinator: and
 taxonomy_type: event
 event_template_types: calendar, events, event
 display_months_out: 3
 show_past_events: false
 enable_single_event_filter: true
-default_events_page: /events
+default_events_page: events

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,16 +1,12 @@
 en:
   PLUGIN_EVENTS:
-    FEED:
-      NAME: %s | Upcoming events
-      DESCRIPTION: %s's upcoming events.
     SIDEBAR_FEED:
       NAME: %s | Events (next %d months)
       DESCRIPTION: %s's events in the next %d months. For more upcoming events: %s
+      MORE_EVENTS: More events.
 fr:
   PLUGIN_EVENTS:
-    FEED:
-        NAME: %s | Prochains évènements
-        DESCRIPTION: Les prochains évènements de %s.
     SIDEBAR_FEED:
       NAME: %s | Évènements (%d prochains mois)
-      DESCRIPTION: Les événements de %s dans les deux prochains mois. Pour plus d'événements à venir : %s
+      DESCRIPTION: Les événements de %s dans les deux prochains mois.
+      MORE_EVENTS: Plus d'évènements.

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,0 +1,16 @@
+en:
+  PLUGIN_EVENTS:
+    FEED:
+      NAME: %s | Upcoming events
+      DESCRIPTION: %s's upcoming events.
+    SIDEBAR_FEED:
+      NAME: %s | Events (next %d months)
+      DESCRIPTION: %s's events in the next %d months. For more upcoming events: %s
+fr:
+  PLUGIN_EVENTS:
+    FEED:
+        NAME: %s | Prochains évènements
+        DESCRIPTION: Les prochains évènements de %s.
+    SIDEBAR_FEED:
+      NAME: %s | Évènements (%d prochains mois)
+      DESCRIPTION: Les événements de %s dans les deux prochains mois. Pour plus d'événements à venir : %s

--- a/languages.yaml
+++ b/languages.yaml
@@ -3,7 +3,7 @@ en:
     MONTH_EVENTS: %s Events
     SIDEBAR_FEED:
       NAME: %s | Events (next %d months)
-      DESCRIPTION: %s's events in the next %d months. For more upcoming events: %s
+      DESCRIPTION: %s's events in the next %d months.
       MORE_EVENTS: More events.
 fr:
   PLUGIN_EVENTS:

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,11 +1,13 @@
 en:
   PLUGIN_EVENTS:
+    MONTH_EVENTS: %s Events
     SIDEBAR_FEED:
       NAME: %s | Events (next %d months)
       DESCRIPTION: %s's events in the next %d months. For more upcoming events: %s
       MORE_EVENTS: More events.
 fr:
   PLUGIN_EVENTS:
+    MONTH_EVENTS: Évènements de %s
     SIDEBAR_FEED:
       NAME: %s | Évènements (%d prochains mois)
       DESCRIPTION: Les événements de %s dans les deux prochains mois.

--- a/templates/calendar.html.twig
+++ b/templates/calendar.html.twig
@@ -63,9 +63,9 @@
 		                            {% for events in calendar.events[calendar.year][calendar.month][day] %}
 		                                {% for event in events %}
 		                                    {% if event.title %}
-		                                        <div class="event">
-		                                        	<span class="event-title"><a href="{{ event.url }}">{{ event.title }}</a></span>
-		                                        	<span class="event-time">{{ event.event.start|date("g:ia") }}-{{ event.event.end|date("g:ia") }}</span>
+		                                        <div class="event h-event">
+		                                        	<span class="event-title"><a href="{{ event.url }}" class="p-name u-url">{{ event.title }}</a></span>
+		                                        	<span class="event-time"><time class="dt-start" datetime="{{ event.event.start|date("c") }}">{{ event.event.start|date("g:ia") }}</time>-<time class="dt-end" datetime="{{ event.event.end|date("c") }}">{{ event.event.end|date("g:ia") }}</time></span>
 		                                        </div>
 		                                    {% endif %}
 		                                {% endfor %}

--- a/templates/calendar.html.twig
+++ b/templates/calendar.html.twig
@@ -24,27 +24,27 @@
 		        <thead>
 		            <tr>
 		                <th colspan="1">
-		                    <a href="{{ prevMonthUrl }}" class="calendar-control">{{ calendar.prev.date|date('F Y') }}</a>
+		                    <a href="{{ prevMonthUrl }}" class="calendar-control">{{ 'MONTHS_OF_THE_YEAR'|ta(calendar.prev.date|date('n') - 1) ~ calendar.prev.date|date(' Y') }}</a>
 		                </th>
 		                <th colspan="5" class="controls">
 		                    <a href="{{ prevMonthUrl }}" class="calendar-button calendar-control">&lsaquo;</a>
 		                    <a href="{{ prevYearUrl }}" class="calendar-button calendar-control">&laquo;</a>
-		                    <span class="title">{{ calendar.date|date('F Y') }}</span>
+		                    <span class="title">{{ 'MONTHS_OF_THE_YEAR'|ta(calendar.date|date('n') - 1) ~ calendar.date|date(' Y') }}</span>
 		                    <a href="{{ nextYearUrl }}" class="calendar-button calendar-control">&raquo;</a>
 		                    <a href="{{ nextMonthUrl }}" class="calendar-button calendar-control">&rsaquo;</a>
 		                </th>
 		                <th colspan="1">
-		                    <a href="{{ nextMonthUrl }}" class="calendar-control">{{ calendar.next.date|date('F Y') }}</a>
+		                    <a href="{{ nextMonthUrl }}" class="calendar-control">{{ 'MONTHS_OF_THE_YEAR'|ta(calendar.next.date|date('n') - 1) ~ calendar.next.date|date(' Y') }}</a>
 		                </th>
 		            </tr>
 		            <tr class="headings">
-		                <th width="14.2%">Sunday</th>
-		                <th width="14.2%">Monday</th>
-		                <th width="14.2%">Tuesday</th>
-		                <th width="14.2%">Wednesday</th>
-		                <th width="14.2%">Thursday</th>
-		                <th width="14.2%">Friday</th>
-		                <th width="14.2%">Saturday</th>
+		                <th width="14.2%">{{ 'DAYS_OF_THE_WEEK'|ta(0) }}</th>
+		                <th width="14.2%">{{ 'DAYS_OF_THE_WEEK'|ta(1) }}</th>
+		                <th width="14.2%">{{ 'DAYS_OF_THE_WEEK'|ta(2) }}</th>
+		                <th width="14.2%">{{ 'DAYS_OF_THE_WEEK'|ta(3) }}</th>
+		                <th width="14.2%">{{ 'DAYS_OF_THE_WEEK'|ta(4) }}</th>
+		                <th width="14.2%">{{ 'DAYS_OF_THE_WEEK'|ta(5) }}</th>
+		                <th width="14.2%">{{ 'DAYS_OF_THE_WEEK'|ta(6) }}</th>
 		            </tr>
 		        </thead>
 		        <tbody>

--- a/templates/events.html.twig
+++ b/templates/events.html.twig
@@ -18,7 +18,7 @@
 			{% endif %}
 
 		<div class="content-wrapper blog-content-list grid pure-g">
-			<div id="listing" class="block pure-u-2-3">
+			<div id="listing" class="block pure-u-2-3 h-feed">
 				{% for child in collection %}
 			        {% include 'partials/event_item.html.twig' with {'event':page, 'page':child, 'truncate':true} %}
 			    {% endfor %}

--- a/templates/events.html.twig
+++ b/templates/events.html.twig
@@ -19,6 +19,10 @@
 
 		<div class="content-wrapper blog-content-list grid pure-g">
 			<div id="listing" class="block pure-u-2-3 h-feed">
+			    <div style="display: none">
+			        <a href="{{ page.url() }}" class="p-name u-url">{{ header.feed.name|default(page.title)|e }}</a>
+			        <p class="p-summary">{{ header.feed.description|default(header.title)|e }}</p>
+			    </div>
 				{% for child in collection %}
 			        {% include 'partials/event_item.html.twig' with {'event':page, 'page':child, 'truncate':true} %}
 			    {% endfor %}

--- a/templates/partials/event_item.html.twig
+++ b/templates/partials/event_item.html.twig
@@ -5,7 +5,7 @@
     {% set header_image_height = page.header.header_image_height|defined(300) %}
     {% set header_image_file = page.header.header_image_file %}
 
-    <div class="list-event-header">
+    <div class="list-event-header h-event h-entry">
         <div class="list-event-date">
             <div class="date">
                 <span class="day">{{ page.header.event.start|date("d") }}</span>
@@ -15,18 +15,18 @@
                 </div>
             </div>
             <div class="time">
-                {{ page.header.event.start|date('gia') }}-{{ page.header.event.end|date('gia') }}
+                <time class="dt-start" datetime="{{ page.date|date("c") }}">{{ page.header.event.start|date('gia') }}</time>-<time class="dt-end" datetime="{{ page.date|date("c") }}">{{ page.header.event.end|date('gia') }}</time>
             </div>
         </div>
         {% if page.header.link %}
-            <h4>
+            <h4 class="p-name">
                 {% if page.header.continue_link is not sameas(false) %}
-                <a href="{{ page.url }}"><i class="fa fa-angle-double-right"></i></a>
+                <a href="{{ page.url }}" class="u-url"><i class="fa fa-angle-double-right"></i></a>
                 {% endif %}
-                <a href="{{ page.header.link }}">{{ page.title }}</a>
+                <a href="{{ page.header.link }}" class="u-url">{{ page.title }}</a>
             </h4>
         {% else %}
-            <h4><a href="{{ page.header.event_url }}">{{ page.title }}</a></h4>
+            <h4 class="p-name"><a href="{{ page.header.event_url }}" class="u-url">{{ page.title }}</a></h4>
         {% endif %}
 
         {% if page.taxonomy.category %}
@@ -40,7 +40,7 @@
         {% if page.taxonomy.tag %}
         <span class="tags">
             {% for tag in page.taxonomy.tag %}
-            <a href="{{ event.url|rtrim('/') }}/tag{{ config.system.param_sep }}{{ tag }}">{{ tag }}</a>
+            <a href="{{ event.url|rtrim('/') }}/tag{{ config.system.param_sep }}{{ tag }}" class="p-category">{{ tag }}</a>
             {% endfor %}
         </span>
         {% endif %}
@@ -63,14 +63,19 @@
         {% set show_prev_next = true %}
         {% endif %}
     {% elseif truncate and page.summary != page.content %}
-        {{ page.summary }}
+        <div class="p-summary">
+            {{ page.summary }}
         <p><a href="{{ page.url }}">Continue Reading...</a></p>
+        </div>
     {% elseif truncate %}
         {% if page.summary != page.content %}
-            {{ page.content|truncate(550) }}
+            <div class="p-summary">
+                {{ page.content|truncate(550) }}
         {% else %}
-            {{ page.content }}
+            <div class="p-description">
+                {{ page.content }}
         {% endif %}
+            </div>
         <p><a href="{{ page.url }}">Continue Reading...</a></p>
     {% else %}
         {% include 'partials/event_meta.html.twig' with {'page':page} %}

--- a/templates/partials/event_item.html.twig
+++ b/templates/partials/event_item.html.twig
@@ -1,20 +1,16 @@
-<div class="list-item">
+<div class="list-item h-event">
 
     {% set header_image = page.header.header_image|defined(true) %}
     {% set header_image_width  = page.header.header_image_width|defined(900) %}
     {% set header_image_height = page.header.header_image_height|defined(300) %}
     {% set header_image_file = page.header.header_image_file %}
 
-    <div class="list-event-header h-event">
+    <div class="list-event-header">
         <div class="list-event-date">
             <div class="date">
                 <span class="day">{{ page.header.event.start|date("d") }}</span>
                 <div class="month-year">
-                    {% if config.plugins.events.date_translate %}
-                    <span class="month">{{ 'MONTHS_OF_THE_YEARS'|ta(page.header.event.start|date('n') - 1) }}</span>
-                    {% else %}
-                    <span class="month">{{ page.header.event.start|date('M') }}</span>
-                    {% endif %}
+                    <span class="month">{{ config.plugins.events.date_format.translate ? 'MONTHS_OF_THE_YEAR'|ta(page.header.event.start|date('n') - 1) : page.header.event.start|date('M') }}</span>
                     <em>{{ page.header.event.start|date("Y") }}</em>
                 </div>
             </div>
@@ -80,7 +76,7 @@
                 {{ page.content }}
         {% endif %}
             </div>
-        <p><a href="{{ page.url }}">Continue Reading...</a></p>
+        <p><a href="{{ page.url }}">{{ 'BLOG.ITEM.CONTINUE_READING'|t }}</a></p>
     {% else %}
         {% include 'partials/event_meta.html.twig' with {'page':page} %}
         {{ page.content }}
@@ -92,11 +88,11 @@
 
         <p class="prev-next">
             {% if not page.isFirst %}
-                <a class="button" href="{{ page.nextSibling.url }}"><i class="fa fa-chevron-left"></i> Next Event</a>
+                <a class="button" href="{{ page.nextSibling.url }}"><i class="fa fa-chevron-left"></i> {{ 'BLOG.ITEM.NEXT_POST'|t }}</a>
             {% endif %}
 
             {% if not page.isLast %}
-                <a class="button" href="{{ page.prevSibling.url }}">Previous Event <i class="fa fa-chevron-right"></i></a>
+                <a class="button" href="{{ page.prevSibling.url }}">{{ 'BLOG.ITEM.PREV_POST'|t }} <i class="fa fa-chevron-right"></i></a>
             {% endif %}
         </p>
     {% endif %}

--- a/templates/partials/event_item.html.twig
+++ b/templates/partials/event_item.html.twig
@@ -5,7 +5,7 @@
     {% set header_image_height = page.header.header_image_height|defined(300) %}
     {% set header_image_file = page.header.header_image_file %}
 
-    <div class="list-event-header h-event h-entry">
+    <div class="list-event-header h-event">
         <div class="list-event-date">
             <div class="date">
                 <span class="day">{{ page.header.event.start|date("d") }}</span>
@@ -15,7 +15,7 @@
                 </div>
             </div>
             <div class="time">
-                <time class="dt-start" datetime="{{ page.date|date("c") }}">{{ page.header.event.start|date('gia') }}</time>-<time class="dt-end" datetime="{{ page.date|date("c") }}">{{ page.header.event.end|date('gia') }}</time>
+                <time class="dt-start" datetime="{{ page.header.event.start|date("c") }}">{{ page.header.event.start|date('gia') }}</time>-<time class="dt-end" datetime="{{ page.header.event.end|date("c") }}">{{ page.header.event.end|date('gia') }}</time>
             </div>
         </div>
         {% if page.header.link %}

--- a/templates/partials/event_item.html.twig
+++ b/templates/partials/event_item.html.twig
@@ -10,7 +10,11 @@
             <div class="date">
                 <span class="day">{{ page.header.event.start|date("d") }}</span>
                 <div class="month-year">
-                    <span class="month">{{ page.header.event.start|date("M") }}</span>
+                    {% if config.plugins.events.date_translate %}
+                    <span class="month">{{ 'MONTHS_OF_THE_YEARS'|ta(page.header.event.start|date('n') - 1) }}</span>
+                    {% else %}
+                    <span class="month">{{ page.header.event.start|date('M') }}</span>
+                    {% endif %}
                     <em>{{ page.header.event.start|date("Y") }}</em>
                 </div>
             </div>

--- a/templates/partials/events_sidebar.html.twig
+++ b/templates/partials/events_sidebar.html.twig
@@ -1,7 +1,10 @@
 <div class="sidebar-content h-feed">
     <div style="display: none;">
         <a class="p-name u-url" href="{{ config.plugins.events.default_events_page }}">{{ "PLUGIN_EVENTS.SIDEBAR_FEED.NAME"|t(site.title|e, 2) }}</a>
-        <p class="p-summary">{{ "PLUGIN_EVENTS.SIDEBAR_FEED.DESCRIPTION"|t(site.title|e, 2, config.plugins.events.default_events_page) }}</p>
+        <p class="p-summary">
+            {{ "PLUGIN_EVENTS.SIDEBAR_FEED.DESCRIPTION"|t(site.title|e, 2) }}
+            <a href="{{ base_url ~ config.plugins.events.default_events_page }}">{{ "PLUGIN_EVENTS.SIDEBAR_FEED.MORE_EVENTS"|t }}</a>
+        </p>
     </div>
     {% set events = page.collection({
         'items':{

--- a/templates/partials/events_sidebar.html.twig
+++ b/templates/partials/events_sidebar.html.twig
@@ -21,7 +21,7 @@
         <h4>{{ curTime|date('F') }} Events</h4>
         <ul>
         {% for event in events %}
-            <li class="h-event h-entry"><time class="dt-start" datetime="{{ event.header.event.start|date("c") }}">{{ event.header.event.start|date('M d')}}</time><time class="dt-end" datetime="{{ event.header.event.end|date("c") }}"></time> <a href="{{ event.url }}" class="u-url p-name">{{ event.title }}</a></li>
+            <li class="h-event"><time class="dt-start" datetime="{{ event.header.event.start|date("c") }}">{{ event.header.event.start|date('M d')}}</time><time class="dt-end" datetime="{{ event.header.event.end|date("c") }}"></time> <a href="{{ event.url }}" class="u-url p-name">{{ event.title }}</a></li>
         {% endfor %}
         </ul>
         {% set curtime = curTime.addMonth() %}

--- a/templates/partials/events_sidebar.html.twig
+++ b/templates/partials/events_sidebar.html.twig
@@ -3,27 +3,34 @@
         <a class="p-name u-url" href="{{ config.plugins.events.default_events_page }}">{{ "PLUGIN_EVENTS.SIDEBAR_FEED.NAME"|t(site.title|e, 2) }}</a>
         <p class="p-summary">{{ "PLUGIN_EVENTS.SIDEBAR_FEED.DESCRIPTION"|t(site.title|e, 2, config.plugins.events.default_events_page) }}</p>
     </div>
-    {% set months = config.plugins.events.sidebar_months %}
-    {% set curTime = clone(datetools) %}
-    
-    {% for i in range(0, months - 1) %}
-        {% set events = page.collection({
-                'items':{
-                    '@taxonomy.type':'event',
-                }
-            })
-            .dateRange(
-                curTime.today,
-                curTime.endOfMonth
-            )
-            .order('date', 'asc')
-        %}
-        <h4>{{ curTime|date('F') }} Events</h4>
-        <ul>
-        {% for event in events %}
-            <li class="h-event"><time class="dt-start" datetime="{{ event.header.event.start|date("c") }}">{{ event.header.event.start|date('M d')}}</time><time class="dt-end" datetime="{{ event.header.event.end|date("c") }}"></time> <a href="{{ event.url }}" class="u-url p-name">{{ event.title }}</a></li>
-        {% endfor %}
-        </ul>
-        {% set curtime = curTime.addMonth() %}
+    {% set events = page.collection({
+        'items':{
+            '@taxonomy.type':'event',
+        }
+    }).dateRange(
+            datetools.startOfMonth,
+            datetools.endOfMonth
+    ).order('date', 'asc')
+    %}
+    <h4>{{ 'PLUGIN_EVENTS.MONTH_EVENTS'|t('MONTHS_OF_THE_YEAR'|ta(datetools.startOfMonth|date('n') -1)) }}</h4>
+    <ul>
+    {% for event in events %}
+        <li class="h-event"><time class="dt-start" datetime="{{ event.header.event.start|date("c") }}">{{ event.header.event.start|date('M d')}}</time><time class="dt-end" datetime="{{ event.header.event.end|date("c") }}"></time> <a href="{{ event.url }}" class="u-url p-name">{{ event.title }}</a></li>
     {% endfor %}
+    </ul>
+    {% set events = page.collection({
+        'items':{
+            '@taxonomy.type':'event',
+        }
+    }).dateRange(
+        datetools.parseDate('first day of next month'),
+        datetools.parseDate('last day of next month')
+    ).order('date', 'asc')
+    %}
+    <h4>{{ 'PLUGIN_EVENTS.MONTH_EVENTS'|t('MONTHS_OF_THE_YEAR'|ta(datetools.parseDate('first day of next month')|date('n') -1)) }}</h4>
+    <ul>
+    {% for event in events %}
+        <li class="h-event"><time class="dt-start" datetime="{{ event.header.event.start|date("c") }}">{{ event.header.event.start|date('M d')}}</time><time class="dt-end" datetime="{{ event.header.event.end|date("c") }}"></time> <a href="{{ event.url }}" class="u-url p-name">{{ event.title }}</a></li>
+    {% endfor %}
+    </ul>
 </div>

--- a/templates/partials/events_sidebar.html.twig
+++ b/templates/partials/events_sidebar.html.twig
@@ -1,6 +1,6 @@
 <div class="sidebar-content h-feed">
     <div style="display: none;">
-        <a class="p-name u-url" href="{{ config.plugins.events.default_events_page }}">{{ "PLUGIN_EVENTS.SIDEBAR_FEED.NAME"|t(site.title|e, 2) }}</a>
+        <a class="p-name u-url" href="{{ base_url ~ config.plugins.events.default_events_page }}">{{ "PLUGIN_EVENTS.SIDEBAR_FEED.NAME"|t(site.title|e, 2) }}</a>
         <p class="p-summary">
             {{ "PLUGIN_EVENTS.SIDEBAR_FEED.DESCRIPTION"|t(site.title|e, 2) }}
             <a href="{{ base_url ~ config.plugins.events.default_events_page }}">{{ "PLUGIN_EVENTS.SIDEBAR_FEED.MORE_EVENTS"|t }}</a>

--- a/templates/partials/events_sidebar.html.twig
+++ b/templates/partials/events_sidebar.html.twig
@@ -1,0 +1,29 @@
+<div class="sidebar-content h-feed">
+    <div style="display: none;">
+        <a class="p-name u-url" href="{{ config.plugins.events.default_events_page }}">{{ "PLUGIN_EVENTS.SIDEBAR_FEED.NAME"|t(site.title|e, 2) }}</a>
+        <p class="p-summary">{{ "PLUGIN_EVENTS.SIDEBAR_FEED.DESCRIPTION"|t(site.title|e, 2, config.plugins.events.default_events_page) }}</p>
+    </div>
+    {% set months = config.plugins.events.sidebar_months %}
+    {% set curTime = clone(datetools) %}
+    
+    {% for i in range(0, months - 1) %}
+        {% set events = page.collection({
+                'items':{
+                    '@taxonomy.type':'event',
+                }
+            })
+            .dateRange(
+                curTime.today,
+                curTime.endOfMonth
+            )
+            .order('date', 'asc')
+        %}
+        <h4>{{ curTime|date('F') }} Events</h4>
+        <ul>
+        {% for event in events %}
+            <li class="h-event h-entry"><time class="dt-start" datetime="{{ event.header.event.start|date("c") }}">{{ event.header.event.start|date('M d')}}</time><time class="dt-end" datetime="{{ event.header.event.end|date("c") }}"></time> <a href="{{ event.url }}" class="u-url p-name">{{ event.title }}</a></li>
+        {% endfor %}
+        </ul>
+        {% set curtime = curTime.addMonth() %}
+    {% endfor %}
+</div>

--- a/templates/partials/sidebar_events.html.twig
+++ b/templates/partials/sidebar_events.html.twig
@@ -10,45 +10,9 @@
 	<h4>Some Text Widget</h4>
 	<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna.</p>
 </div>
-<div class="sidebar-content">
-	<h4>{{ datetools.startOfMonth|date('F') }} Events</h4>
-    {% set events =
-        page.collection({
-            'items':{
-                '@taxonomy.type':'event',
-            }
-        })
-        .dateRange(
-            datetools.startOfMonth,
-            datetools.endOfMonth
-        )
-        .order('date', 'asc')
-    %}
-    <ul>
-    {% for event in events %}
-        <li>{{ event.header.event.start|date('M d')}} <a href="{{ event.url }}">{{ event.title }}</a></li>
-    {% endfor %}
-    </ul>
-
-    <h4>{{ datetools.parseDate('first day of next month')|date('F') }} Events</h4>
-    {% set events2 =
-        page.collection({
-            'items':{
-                '@taxonomy.type':'event',
-            }
-        })
-        .dateRange(
-            datetools.parseDate('first day of next month'),
-            datetools.parseDate('last day of next month')
-        )
-        .order('date', 'asc')
-    %}
-    <ul>
-    {% for event in events2 %}
-        <li>{{ event.header.event.start|date('M d')}} <a href="{{ event.url }}">{{ event.title }}</a></li>
-    {% endfor %}
-    </ul>
-</div>
+{% if config.plugins.events.enabled %}
+    {% include 'partials/events_sidebar.html.twig' %}
+{% endif %}
 {% if config.plugins.taxonomylist.enabled %}
 <div class="sidebar-content">
     <h4>Popular Tags</h4>


### PR DESCRIPTION
Hi,

I've added [microformats2](http://microformats.org) support to your plugin for semantic markup, as well as translations support using some of the tools provided by Grav/Antimatter.

I've updated the README and CHANGELOG consequently.

The hours is the only element not translated yet. I guess if we want to go further, using something like [this](https://github.com/jenssegers/date) is necessary (interesting for datetools).

If you have any questions/requests regarding this pull-request, don't hesitate!

You can see the code in action [here](https://events.subversive.audio).

Thanks for your amazing plugin!

PS: I've taken the liberty of updating version number to 1.0.10 everywhere, as it's the version that's being displayed in GPM. Otherwise, one is always prompted for updates even running the latest version. Also, you should probably bump it again if you accept to merge this PR :)
